### PR TITLE
Fix warnings about unescaped { on perl 5.17.6+

### DIFF
--- a/lib/XML/Simple.pm
+++ b/lib/XML/Simple.pm
@@ -1007,7 +1007,7 @@ sub collapse {
 
   if(my $var = $self->{_var_values}) {
     while(my($key, $val) = each(%$attr)) {
-      $val =~ s{\$\{([\w.]+)\}}{ $self->get_var($1) }ge;
+      $val =~ s^\$\{([\w.]+)\}^ $self->get_var($1) ^ge;
       $attr->{$key} = $val;
     }
   }
@@ -1044,7 +1044,7 @@ sub collapse {
       # do variable substitutions
 
       if(my $var = $self->{_var_values}) {
-        $val =~ s{\$\{(\w+)\}}{ $self->get_var($1) }ge;
+        $val =~ s^\$\{(\w+)\}^ $self->get_var($1) ^ge;
       }
 
 

--- a/t/8_Namespaces.t
+++ b/t/8_Namespaces.t
@@ -122,16 +122,16 @@ $opt = {
 };
 
 $xml = XMLout($opt);
-like($xml, qr{
+like($xml, qr[
   ^\s*<opt
   (\s+{http://www.w3.org/2000/xmlns/}perl="http://www.perl.com/"
   |\s+{http://www.perl.com/}attr="value"
   |\s+bare="Beer!"){3}
   \s*>
-  \s*<{http://www.perl.com/}element\s*>data</{http://www.perl.com/}element\s*>
+  \s*<\{http://www.perl.com/\}element\s*>data</\{http://www.perl.com/\}element\s*>
   \s*</opt>
   \s*$
-}sx, 'clarkian names not converted to qnames on output by default');
+]sx, 'clarkian names not converted to qnames on output by default');
 
 
 # Confirm nsexpand option works on output


### PR DESCRIPTION
Unforunately, when you have

```perl
$x =~ s{ \{  }{ bar  }
```

All that the \ escapes is "is this a regexp token", ie:

is no different to its behaviour inside

```perl
$x =~ s[ \{ ][ bar ]
```

And upstream changes mean you now have to escape the delimiting as well now, so I think

```perl
$x =~ s{ \\{  }{ }
```

Is the "right" way to do it. Though, I'm not entirely sure about that either.

Either way, its easier to chose a non-conflicting delimiter token

```perl
$x =~ s[ \{ ][ ]
```

and that should do what you want.