### PR TITLE
Allow special escaping of whitespace in attribute values

### DIFF
--- a/t/2_XMLout.t
+++ b/t/2_XMLout.t
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 use Test::More;
 
-plan tests => 201;
+plan tests => 205;
 
 
 ##############################################################################
@@ -1186,6 +1186,26 @@ SKIP: {
     $ents = join ',', sort ($xml =~ m{&#(\d+);}g);
     is($ents, '8364', "Level 1 numeric escaping looks good");
 }
+
+# Try out the AttrPreserveSpace option
+
+$ref = { aaa => { s => "a\x0Ab\x0D\x0Ac\x09d e" } };
+
+$xml = XMLout($ref);   # Default: no special escaping
+my $ents = join ',', sort ($xml =~ m{&#(\d+);}g);
+is($ents, '', "No attribute whitespace escaping by default");
+
+$xml = XMLout($ref, AttrPreserveSpace => 0);
+$ents = join ',', sort ($xml =~ m{&#(\d+);}g);
+is($ents, '', "No attribute whitespace escaping: explicit");
+
+$xml = XMLout($ref, AttrPreserveSpace => 1);
+$ents = join ',', sort ($xml =~ m{&#(\d+);}g);
+is($ents, '10,10,13,9', "Level 1 attribute escaping looks good");
+
+$xml = XMLout($ref, AttrPreserveSpace => 2);
+$ents = join ',', sort ($xml =~ m{&#(\d+);}g);
+is($ents, '10,10,13,32,9', "Level 2 attribute escaping looks good");
 
 # 'Stress test' with a data structure that maps to several thousand elements.
 # Unfold elements with XMLout() and fold them up again with XMLin()


### PR DESCRIPTION
XML normalization can get in the way if you're trying to put data with literal newlines, tabs, etc. in attribute values, as it requires them to be replaced with spaces by the processor.  This can be avoided by escaping them:

> Note that if the unnormalized attribute value contains a character reference to a white space character other than space (#x20), the normalized value contains the referenced character itself (#xD, #xA or #x9). This contrasts with the case where the unnormalized value contains a white space character (not a reference), which is replaced with a space character (#x20) in the normalized value and also contrasts with the case where the unnormalized value contains an entity reference whose replacement text contains a white space character; being recursively processed, the white space character is replaced with a space character (#x20) in the normalized value.
> (http://www.w3.org/TR/REC-xml/#AVNormalize)

This gives an option for doing so.
