### PR TITLE
allow subclass to override attribute encoding

### DIFF
--- a/lib/XML/Simple.pm
+++ b/lib/XML/Simple.pm
@@ -1568,11 +1568,12 @@ sub value_to_xml {
             $self->value_to_xml($value, $key, "$indent  ");
         }
         else {
-          $value = $self->escape_value($value) unless($self->{opt}->{noescape});
           if($key eq $self->{opt}->{contentkey}) {
+            $value = $self->escape_value($value) unless($self->{opt}->{noescape});
             $text_content = $value;
           }
           else {
+            $value = $self->escape_attr($value) unless($self->{opt}->{noescape});
             push @result, "\n$indent " . ' ' x length($name)
               if($self->{opt}->{attrindent}  and  !$first_arg);
             push @result, ' ', $key, '="', $value , '"';
@@ -1716,6 +1717,19 @@ sub numeric_escape {
   }
 
   return $data;
+}
+
+##############################################################################
+# Method: escape_attr()
+#
+# Helper routine for escaping attribute values.  Defaults to escape_value(),
+# but may be overridden by a subclass to customise behaviour.
+#
+
+sub escape_attr {
+  my $self = shift;
+
+  return $self->escape_value(@_);
 }
 
 
@@ -2881,6 +2895,12 @@ should appear in the output.
 
 Called from C<XMLout()>, takes a string and returns a copy of the string with
 XML character escaping rules applied.
+
+=item escape_attr(string)
+
+Called from C<XMLout()>, to handle attribute values.  By default, just calls
+C<escape_value()>, but you can override this method if you want attributes
+escaped differently than text content.
 
 =item numeric_escape(string)
 


### PR DESCRIPTION
My application does not work correctly unless it is able to escape attribute values in such a way that whitespace is preserved, while leaving text content to the "standard" escaping.  I think this is a generally useful thing to do and one of the dark corners of XML that gets forgotten about until someone puts a newline in an attribute and something breaks.

I understand your reluctance to add more options to the API, so how about this small refactoring that makes the escaping of attribute values a separate hook, so that people can at least override it in a supported way?  Otherwise, the code that needs to be touched is in the middle of the large, non-public value_to_xml() routine.

I hope you will consider this pull request or an alternate approach to achieve the same end.  I very much prefer to minimize the amount of monkey patching or shipping custom versions of third-party modules in my code base.

Thanks!
Chris