### PR TITLE
- Fixed typo in the pod document link to package XML::SAX::ParseFactory.

### DIFF
--- a/lib/XML/Simple.pm
+++ b/lib/XML/Simple.pm
@@ -3097,7 +3097,7 @@ installed).
 =item *
 
 If the 'preferred parser' is set to some other value, then it is assumed to be
-the name of a SAX parser module and is passed to L<XML::SAX::ParserFactory.>
+the name of a SAX parser module and is passed to L<XML::SAX::ParserFactory>
 If L<XML::SAX> is not installed, or the requested parser module is not
 installed, then C<XMLin()> will die.
 


### PR DESCRIPTION
Hi Grant, please review the above change.

Many Thanks.
Best Regards,
Mohammad S Anwar