### PR TITLE
Handle objects that overload stringification

### DIFF
--- a/lib/XML/Simple.pm
+++ b/lib/XML/Simple.pm
@@ -1645,7 +1645,12 @@ sub value_to_xml {
   }
 
   else {
-    croak "Can't encode a value of type: " . ref($ref);
+    # Before giving up, check if stringification is overloaded.
+    if (overload::OverloadedStringify($ref)) {
+      push @result, "$indent<$name>$ref</$name>$nl";
+    } else {
+      croak "Can't encode a value of type: " . ref($ref);
+    }
   }
 
 


### PR DESCRIPTION
This fixes a problem that we've just seen at my current client. But I think it might be more widely useful.

And, yes, I know that the real fix is to stop using XML::Simple. But that's not going to happen any time soon :-(