### PR TITLE
Prevent external entity attacks when using XML::Parser

### DIFF
--- a/lib/XML/Simple.pm
+++ b/lib/XML/Simple.pm
@@ -60,7 +60,7 @@ my %StrictMode     = ();
 my @KnownOptIn     = qw(keyattr keeproot forcecontent contentkey noattr
                         searchpath forcearray cache suppressempty parseropts
                         grouptags nsexpand datahandler varattr variables
-                        normalisespace normalizespace valueattr strictmode);
+                        normalisespace normalizespace valueattr strictmode expandexternents);
 
 my @KnownOptOut    = qw(keyattr keeproot contentkey noattr
                         rootname xmldecl outputfile noescape suppressempty
@@ -428,6 +428,10 @@ sub build_tree_xml_parser {
   }
 
   my $xp = XML::Parser->new(Style => 'Tree', @{$self->{opt}->{parseropts}});
+  unless ($self->{opt}->{expandexternents}) {
+      $xp->setHandlers(ExternEnt => sub {return $_[2]});
+  }
+
   my($tree);
   if($filename) {
     # $tree = $xp->parsefile($filename);  # Changed due to prob w/mod_perl
@@ -767,6 +771,8 @@ sub handle_options  {
     $opt->{normalisespace} = $opt->{normalizespace};
   }
   $opt->{normalisespace} = 0 unless(defined($opt->{normalisespace}));
+
+  $opt->{expandexternents} = 0 unless(defined($opt->{expandexternents}));
 
   # Cleanups for values assumed to be arrays later
 

--- a/lib/XML/Simple.pm
+++ b/lib/XML/Simple.pm
@@ -60,7 +60,7 @@ my %StrictMode     = ();
 my @KnownOptIn     = qw(keyattr keeproot forcecontent contentkey noattr
                         searchpath forcearray cache suppressempty parseropts
                         grouptags nsexpand datahandler varattr variables
-                        normalisespace normalizespace valueattr strictmode expandexternents);
+                        normalisespace normalizespace valueattr strictmode);
 
 my @KnownOptOut    = qw(keyattr keeproot contentkey noattr
                         rootname xmldecl outputfile noescape suppressempty
@@ -428,9 +428,7 @@ sub build_tree_xml_parser {
   }
 
   my $xp = XML::Parser->new(Style => 'Tree', @{$self->{opt}->{parseropts}});
-  unless ($self->{opt}->{expandexternents}) {
-      $xp->setHandlers(ExternEnt => sub {return $_[2]});
-  }
+  $xp->setHandlers(ExternEnt => sub {return $_[2]});
 
   my($tree);
   if($filename) {
@@ -771,8 +769,6 @@ sub handle_options  {
     $opt->{normalisespace} = $opt->{normalizespace};
   }
   $opt->{normalisespace} = 0 unless(defined($opt->{normalisespace}));
-
-  $opt->{expandexternents} = 0 unless(defined($opt->{expandexternents}));
 
   # Cleanups for values assumed to be arrays later
 

--- a/t/C_External_Entities.t
+++ b/t/C_External_Entities.t
@@ -1,0 +1,35 @@
+use strict;
+use warnings;
+use Test::More;
+use File::Temp qw(tempfile);
+
+eval { require XML::Parser; };
+if($@) {
+  plan skip_all => 'no XML::Parser';
+}
+
+plan tests => 2;
+
+use XML::Simple;
+
+$XML::Simple::PREFERRED_PARSER = 'XML::Parser';
+
+my ($fh, $filename) = tempfile(UNLINK => 1);
+print $fh "bad";
+close $fh;
+
+my $xml = qq(<?xml version="1.0"?>
+<!DOCTYPE foo [ <!ELEMENT foo ANY >
+<!ENTITY xxe SYSTEM "file://$filename" >]>
+<creds>
+    <user>&xxe;</user>
+    <pass>mypass</pass>
+</creds>
+);
+
+my $opt = XMLin($xml);
+isnt($opt->{'user'}, 'bad', 'External entity not retrieved');
+like($opt->{'user'}, qr/^file/, 'External entity left as URL');
+
+unlink($filename) if (-f $filename);
+exit(0);


### PR DESCRIPTION
The #4 item on the OWASP top 10 is external XML entities.  When using XML::Parser, XML::Simple is currently vulnerable by default.
It is not when using XML::Sax.  Parsing this XML under XML::Parser vs XML::Sax will show the difference:
```

<?xml version="1.0"?>
<!DOCTYPE foo [ <!ELEMENT foo ANY >
<!ENTITY xxe SYSTEM "file:///etc/passwd" >]>
<creds>
    <user>&xxe;</user>
    <pass>mypass</pass>
</creds>

```
That example shows a file-based external entity. They can also be web URLs.

As XML::Simple is intended to be simple, it should not by default read and inject external resources.
The expandexternents option can be used if external entities are desired.