### PR TITLE
XML::Parser entity (non-)expansion improvements

### DIFF
--- a/lib/XML/Simple.pm
+++ b/lib/XML/Simple.pm
@@ -454,7 +454,7 @@ sub new_xml_parser {
   my($self) = @_;
 
   my $xp = XML::Parser->new(Style => 'Tree', @{$self->{opt}->{parseropts}});
-  $xp->setHandlers(ExternEnt => sub {return $_[2]});
+  $xp->setHandlers(ExternEnt => sub {return ''});
 
   return $xp;
 }

--- a/lib/XML/Simple.pm
+++ b/lib/XML/Simple.pm
@@ -453,8 +453,9 @@ sub build_tree_xml_parser {
 sub new_xml_parser {
   my($self) = @_;
 
-  my $xp = XML::Parser->new(Style => 'Tree', @{$self->{opt}->{parseropts}});
-  $xp->setHandlers(ExternEnt => sub {return ''});
+  my $xp = XML::Parser->new(Style => 'Tree', NoExpand => 1,
+                            @{$self->{opt}->{parseropts}});
+  $xp->setHandlers(ExternEnt => sub {return ''}, Default => sub {});
 
   return $xp;
 }

--- a/t/C_External_Entities.t
+++ b/t/C_External_Entities.t
@@ -29,7 +29,7 @@ my $xml = qq(<?xml version="1.0"?>
 
 my $opt = XMLin($xml);
 isnt($opt->{'user'}, 'bad', 'External entity not retrieved');
-like($opt->{'user'}, qr/^file/, 'External entity left as URL');
+is_deeply($opt->{'user'}, {}, 'External entity left as empty');
 
 unlink($filename) if (-f $filename);
 exit(0);

--- a/t/E_Internal_Entities.t
+++ b/t/E_Internal_Entities.t
@@ -1,0 +1,26 @@
+use strict;
+use warnings;
+use Test::More;
+
+eval { require XML::Parser; };
+if($@) {
+  plan skip_all => 'no XML::Parser';
+}
+
+plan tests => 2;
+
+use XML::Simple;
+
+$XML::Simple::PREFERRED_PARSER = 'XML::Parser';
+
+my $xml = qq(<?xml version="1.0"?>
+<!DOCTYPE foo [
+<!ENTITY b "XML bomb" >]>
+<foo>&b;</foo>
+);
+
+my $opt = XMLin($xml);
+isnt($opt, 'XML bomb', 'Internal subset entity not expanded');
+is_deeply($opt, {}, 'Internal subset entity left as empty');
+
+exit(0);


### PR DESCRIPTION
Returning empty instead of the system id is more consistent with other implementations, including SAX behavior.

Preventing internal subset entity expansion helps against https://en.wikipedia.org/wiki/Billion_laughs_attack