### PR TITLE
Disable external entities with SAX

### DIFF
--- a/lib/XML/Simple.pm
+++ b/lib/XML/Simple.pm
@@ -381,7 +381,7 @@ sub build_tree {
 
   $XML::SAX::ParserPackage = $preferred_parser if($preferred_parser);
 
-  my $sp = XML::SAX::ParserFactory->parser(Handler => $self);
+  my $sp = $self->new_sax_parser();
 
   $self->{nocollapse} = 1;
   my($tree);
@@ -457,6 +457,23 @@ sub new_xml_parser {
   $xp->setHandlers(ExternEnt => sub {return $_[2]});
 
   return $xp;
+}
+
+
+##############################################################################
+# Method: new_sax_parser()
+#
+# Instantiates a new SAX parser.  Override this method to customise
+# the behaviour of the parser.
+#
+
+sub new_sax_parser {
+  my($self, $handler) = @_;
+  $handler = $self unless defined($handler);
+
+  my $sp = XML::SAX::ParserFactory->parser(Handler => $handler);
+
+  return $sp;
 }
 
 
@@ -685,9 +702,7 @@ sub XMLout {
   }
   elsif($self->{opt}->{handler}) {
     require XML::SAX;
-    my $sp = XML::SAX::ParserFactory->parser(
-               Handler => $self->{opt}->{handler}
-             );
+    my $sp = $self->new_sax_parser($self->{opt}->{handler});
     return($sp->parse_string($xml));
   }
   else {

--- a/lib/XML/Simple.pm
+++ b/lib/XML/Simple.pm
@@ -473,6 +473,13 @@ sub new_sax_parser {
 
   my $sp = XML::SAX::ParserFactory->parser(Handler => $handler);
 
+  my @supported_features = $sp->supported_features();
+  foreach my $enttype (qw(general parameter)) {
+      my $feature = "http://xml.org/sax/features/external-$enttype-entities";
+      $sp->set_feature($feature, 0)
+          if (grep { $_ eq $feature } @supported_features);
+  }
+
   return $sp;
 }
 


### PR DESCRIPTION
Not all SAX drivers support this; XML::SAX::ExpatXS is one that does, and XML::SAX::Expat will as result of https://github.com/hoehrmann/XML-SAX-Expat/pull/3.